### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/public/hybrid-communication.js
+++ b/public/hybrid-communication.js
@@ -271,7 +271,7 @@ export class HybridCommunicationManager {
    * Process incoming message
    */
   processMessage(message) {
-    console.log(`[HybridComm] ${this.windowId} processing message type="${message.type}"`, message);
+    console.log('[HybridComm] %s processing message type="%s"', this.windowId, message.type, message);
     
     // Track known windows
     if (message.type === 'windowJoined' && message.data?.windowId) {


### PR DESCRIPTION
Potential fix for [https://github.com/EelcoLos/iframe-dnd-demo/security/code-scanning/1](https://github.com/EelcoLos/iframe-dnd-demo/security/code-scanning/1)

General fix approach: Avoid using attacker-controlled values directly as the format string argument to `console.log`. Instead, use a constant literal format string and pass untrusted values as additional arguments (or interpolate them into a non-formatting-safe position via `%s` if using real format specifiers).

Best fix here: Change the log line on 274 from using a template literal as the first argument to `console.log` to using a static string and passing `message.type` as a separate argument. That removes any chance that `%` sequences inside `message.type` will be interpreted as format specifiers while preserving all existing log content and structure.

Concretely, in `public/hybrid-communication.js`, within `processMessage(message)`:

- Replace:
  ```js
  console.log(`[HybridComm] ${this.windowId} processing message type="${message.type}"`, message);
  ```
- With:
  ```js
  console.log('[HybridComm] %s processing message type="%s"', this.windowId, message.type, message);
  ```
  or, if you prefer not to rely on `%` at all:
  ```js
  console.log('[HybridComm]', this.windowId, 'processing message type="' + String(message.type) + '"', message);
  ```

Both versions use a constant first argument. The `%s` variant is closest in spirit to the recommendation and does not treat `message.type` as a format string. No imports or new helpers are required and no functionality changes (the log still shows the window id, the type, and the message object).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
